### PR TITLE
add section status badges (OPEN/WAITLISTED/CLOSED)

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -4,11 +4,10 @@ import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { sendLookup } from '../shared/messages';
 import type { PageStats } from '../shared/messages';
-import type { GradeData, MeetingTime, RmpData, SavedSection } from '../shared/types';
+import type { GradeData, MeetingTime, RmpData, SavedSection, SeatData, SectionStatus } from '../shared/types';
 import { storageGet, saveSection, removeSection } from '../shared/storage';
 import { parseMeetingFromApi } from '../shared/conflictDetection';
 import { gpaColorClass } from '../shared/gradeUtils';
-import type { SeatData, SectionStatus } from '../shared/types';
 import { mountPanel, rerenderPanel, unmountPanel } from './mount';
 import SectionComparison, { type InstructorData } from './components/SectionComparison';
 import CourseSearch from './components/CourseSearch';
@@ -385,31 +384,34 @@ async function injectSaveButton(tbody: Element, section: SavedSection) {
 
 const STATUS_ATTR = 'data-trp-status';
 
-function sectionStatus(seats: SeatData): SectionStatus {
-  if (seats.openSeats === undefined) return 'CLOSED'; // unknown — default to closed
-  if (seats.openSeats > 0) return 'OPEN';
+function sectionStatus(seats: SeatData): SectionStatus | null {
+  // All fields undefined means the API didn't return seat data — don't show a badge
+  if (seats.openSeats === undefined && seats.waitlistCount === undefined) return null;
+  if ((seats.openSeats ?? 0) > 0) return 'OPEN';
   if ((seats.waitlistCount ?? 0) > 0) return 'WAITLISTED';
   return 'CLOSED';
 }
 
 function injectStatusBadge(tbody: Element, crn: string) {
-  const firstRow = tbody.querySelector('tr');
-  if (!firstRow) return;
-
-  // Find the CRN cell
-  let crnTd: Element | null = null;
-  for (const td of firstRow.querySelectorAll('td')) {
-    if (/^\d{5}$/.test(td.textContent?.trim() ?? '')) { crnTd = td; break; }
-  }
-  if (!crnTd) return;
-
   const seats = crnSeats.get(crn);
   if (!seats) return;
+
+  const status = sectionStatus(seats);
+
+  // Find the CRN cell — we know the exact CRN string so match it directly
+  const firstRow = tbody.querySelector('tr');
+  if (!firstRow) return;
+  let crnTd: Element | null = null;
+  for (const td of firstRow.querySelectorAll('td')) {
+    if (td.textContent?.trim() === crn) { crnTd = td; break; }
+  }
+  if (!crnTd) return;
 
   // Remove stale badge before re-injecting (e.g., after a manual refresh)
   crnTd.querySelector(`[${STATUS_ATTR}]`)?.remove();
 
-  const status = sectionStatus(seats);
+  if (!status) return; // no known seat data — don't inject a badge
+
   const badge = document.createElement('span');
   badge.setAttribute(STATUS_ATTR, status);
   badge.className = `trp-status-badge trp-status-${status.toLowerCase()}`;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -8,6 +8,7 @@ import type { GradeData, MeetingTime, RmpData, SavedSection } from '../shared/ty
 import { storageGet, saveSection, removeSection } from '../shared/storage';
 import { parseMeetingFromApi } from '../shared/conflictDetection';
 import { gpaColorClass } from '../shared/gradeUtils';
+import type { SeatData, SectionStatus } from '../shared/types';
 import { mountPanel, rerenderPanel, unmountPanel } from './mount';
 import SectionComparison, { type InstructorData } from './components/SectionComparison';
 import CourseSearch from './components/CourseSearch';
@@ -18,13 +19,34 @@ const BADGE_ATTR = 'data-trp';
 
 
 const crnMeetings = new Map<string, MeetingTime[]>();
+const crnSeats = new Map<string, SeatData>();
 
-// Receive meeting data relayed from the MAIN world interceptor (interceptor.ts)
+// Receive meeting + seat data relayed from the MAIN world interceptor (interceptor.ts)
 window.addEventListener('message', (e) => {
   if (e.data?.type !== '__TRP_MEETINGS__') return;
   const meetings = (e.data.meetings ?? []) as { daysRaw: string; startTime: number; endTime: number; location?: string }[];
   const times = meetings.map(parseMeetingFromApi);
   if (times.length) crnMeetings.set(String(e.data.crn), times);
+
+  const crn = String(e.data.crn);
+  const seatData: SeatData = {
+    openSeats: e.data.openSeats,
+    totalSeats: e.data.totalSeats,
+    waitlistCount: e.data.waitlistCount,
+  };
+  // Warn if all seat fields are missing — likely means API field names changed
+  if (seatData.openSeats === undefined && seatData.totalSeats === undefined && seatData.waitlistCount === undefined) {
+    console.warn('[TRP] No seat data in regblocks for CRN', crn, '— field names may have changed');
+  }
+  crnSeats.set(crn, seatData);
+
+  // Inject/update status badge now that we have seat data
+  for (const tbody of document.querySelectorAll('tbody')) {
+    if (getCrnFromTbody(tbody) === crn) {
+      injectStatusBadge(tbody, crn);
+      break;
+    }
+  }
 });
 
 // ─── course-level tracking ────────────────────────────────────────────────────
@@ -359,6 +381,42 @@ async function injectSaveButton(tbody: Element, section: SavedSection) {
   });
 }
 
+// ─── section status badges ────────────────────────────────────────────────────
+
+const STATUS_ATTR = 'data-trp-status';
+
+function sectionStatus(seats: SeatData): SectionStatus {
+  if (seats.openSeats === undefined) return 'CLOSED'; // unknown — default to closed
+  if (seats.openSeats > 0) return 'OPEN';
+  if ((seats.waitlistCount ?? 0) > 0) return 'WAITLISTED';
+  return 'CLOSED';
+}
+
+function injectStatusBadge(tbody: Element, crn: string) {
+  const firstRow = tbody.querySelector('tr');
+  if (!firstRow) return;
+
+  // Find the CRN cell
+  let crnTd: Element | null = null;
+  for (const td of firstRow.querySelectorAll('td')) {
+    if (/^\d{5}$/.test(td.textContent?.trim() ?? '')) { crnTd = td; break; }
+  }
+  if (!crnTd) return;
+
+  const seats = crnSeats.get(crn);
+  if (!seats) return;
+
+  // Remove stale badge before re-injecting (e.g., after a manual refresh)
+  crnTd.querySelector(`[${STATUS_ATTR}]`)?.remove();
+
+  const status = sectionStatus(seats);
+  const badge = document.createElement('span');
+  badge.setAttribute(STATUS_ATTR, status);
+  badge.className = `trp-status-badge trp-status-${status.toLowerCase()}`;
+  badge.textContent = status;
+  crnTd.appendChild(badge);
+}
+
 // ─── CRN copy buttons ─────────────────────────────────────────────────────────
 
 const COPY_ATTR = 'data-trp-copy';
@@ -400,10 +458,12 @@ function scanNode(root: Element | Document) {
   for (const li of findInstructorLis(root)) {
     processLi(li);
   }
-  // Inject CRN copy buttons on all tbodies in scope
+  // Inject CRN copy buttons and status badges on all tbodies in scope
   const tbodyRoot = root instanceof Document ? document.body : root;
   for (const tbody of tbodyRoot.querySelectorAll('tbody')) {
     injectCrnCopyButton(tbody);
+    const crn = getCrnFromTbody(tbody);
+    if (crn) injectStatusBadge(tbody, crn);
   }
 }
 

--- a/src/content/interceptor.ts
+++ b/src/content/interceptor.ts
@@ -11,13 +11,22 @@
 
     if (url.includes('/regblocks')) {
       res.clone().json().then((data: {
-        sections?: { crn: number | string; meetings?: unknown[] }[];
+        sections?: {
+          crn: number | string;
+          meetings?: unknown[];
+          openSeats?: number;
+          totalSeats?: number;
+          waitlistCount?: number;
+        }[];
       }) => {
         for (const section of data.sections ?? []) {
           window.postMessage({
             type: '__TRP_MEETINGS__',
             crn: String(section.crn),
             meetings: section.meetings ?? [],
+            openSeats: section.openSeats,
+            totalSeats: section.totalSeats,
+            waitlistCount: section.waitlistCount,
           }, '*');
         }
       }).catch(() => {});

--- a/src/content/styles/content.css
+++ b/src/content/styles/content.css
@@ -230,12 +230,13 @@
 /* ─── Section status badges ─────────────────────────────────────────────────── */
 
 .trp-status-badge {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   margin-left: 6px;
   padding: 1px 6px;
   border-radius: 8px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.03em;
   vertical-align: middle;

--- a/src/content/styles/content.css
+++ b/src/content/styles/content.css
@@ -226,3 +226,36 @@
 .trp-save-btn.trp-saved {
   color: #500000;
 }
+
+/* ─── Section status badges ─────────────────────────────────────────────────── */
+
+.trp-status-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  vertical-align: middle;
+  border: 1px solid transparent;
+}
+
+.trp-status-open {
+  background: #d1fae5;
+  color: #065f46;
+  border-color: #6ee7b7;
+}
+
+.trp-status-waitlisted {
+  background: #fef9c3;
+  color: #713f12;
+  border-color: #fde047;
+}
+
+.trp-status-closed {
+  background: #fee2e2;
+  color: #7f1d1d;
+  border-color: #fca5a5;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -63,3 +63,11 @@ export interface ApiSection {
   instructor: { name: string; id?: string }[];
   meetings: ApiMeeting[];
 }
+
+export interface SeatData {
+  openSeats: number | undefined;
+  totalSeats: number | undefined;
+  waitlistCount: number | undefined;
+}
+
+export type SectionStatus = 'OPEN' | 'WAITLISTED' | 'CLOSED';


### PR DESCRIPTION
## Summary
- Extends the `regblocks` fetch interceptor to relay `openSeats`, `totalSeats`, and `waitlistCount` per section alongside existing meeting data
- Content script derives enrollment status (OPEN / WAITLISTED / CLOSED) and injects a color-coded pill badge next to the CRN in each section row
- Badges update immediately when seat data arrives from the API and re-inject on manual data refresh (stale badges are removed before re-injection)
- Adds a warning log if all three seat fields are undefined, making field-name drift detectable without silent failures

## Test plan
- [ ] Load schedule builder with at least one course that has sections in different states
- [ ] Confirm OPEN sections show green "OPEN" badge next to CRN
- [ ] Confirm WAITLISTED sections show yellow "WAITLISTED" badge
- [ ] Confirm full sections with no waitlist show red "CLOSED" badge
- [ ] Confirm badge appears after grade data loads (async path)
- [ ] Open DevTools console — no `[TRP] No seat data` warnings for real sections

Closes #3