### PR TITLE
add duplicate button to schedule plans

### DIFF
--- a/src/calendar/App.tsx
+++ b/src/calendar/App.tsx
@@ -213,7 +213,13 @@ export default function App() {
                 {activeSchedule.name} (click to rename)
               </span>
             )}
-            <button style={S.deleteBtn} onClick={handleDuplicateSchedule}>Duplicate</button>
+            <button
+              style={{ ...S.deleteBtn, color: '#60a5fa', borderColor: '#1d4ed8' }}
+              title="Duplicate schedule"
+              onClick={handleDuplicateSchedule}
+            >
+              Duplicate
+            </button>
             <button style={S.deleteBtn} onClick={handleDelete}>Delete schedule</button>
           </div>
         )}

--- a/src/calendar/App.tsx
+++ b/src/calendar/App.tsx
@@ -140,6 +140,18 @@ export default function App() {
     await deleteSchedule(activeId);
   }
 
+  async function handleDuplicateSchedule() {
+    if (!activeSchedule) return;
+    const newSched: Schedule = {
+      id: genId(),
+      name: `${activeSchedule.name} Copy`,
+      sectionCrns: [...activeSchedule.sectionCrns],
+      createdAt: Date.now(),
+    };
+    await saveSchedule(newSched);
+    await setActiveSchedule(newSched.id);
+  }
+
   async function handleRenameCommit() {
     if (!activeSchedule || !renameVal.trim()) { setRenaming(false); return; }
     await saveSchedule({ ...activeSchedule, name: renameVal.trim() });
@@ -201,6 +213,7 @@ export default function App() {
                 {activeSchedule.name} (click to rename)
               </span>
             )}
+            <button style={S.deleteBtn} onClick={handleDuplicateSchedule}>Duplicate</button>
             <button style={S.deleteBtn} onClick={handleDelete}>Delete schedule</button>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Adds a `handleDuplicateSchedule` function that deep-copies the active plan (new UUID, same section CRNs, name suffixed with " Copy")
- New plan is immediately set as active after duplication
- "Duplicate" button placed in the schedule controls bar next to the existing "Delete schedule" button

## Test plan
- [ ] Open calendar with at least one named plan containing sections
- [ ] Click "Duplicate" — new tab appears named "{original} Copy" and becomes active
- [ ] Verify duplicated plan has same sections as the original
- [ ] Rename, add/remove sections in the copy — original plan unaffected
- [ ] Duplicate a plan that was itself a copy — names stack correctly (e.g., "Plan A Copy Copy")

Closes #9