### PR TITLE
Add CIS evaluation links per instructor

### DIFF
--- a/src/content/components/CourseSearch.tsx
+++ b/src/content/components/CourseSearch.tsx
@@ -4,6 +4,7 @@ import type { RankedInstructor } from '../../shared/messages';
 import type { ApiMeeting, ApiSection, MeetingTime, SavedSection } from '../../shared/types';
 import { saveSection } from '../../shared/storage';
 import { parseMeetingFromApi } from '../../shared/conflictDetection';
+import { parseName } from '../../shared/nameMatch';
 
 const SCHEDULER_BASE = 'https://tamu.collegescheduler.com';
 
@@ -217,9 +218,9 @@ function InstructorCard({
         rmpData && createElement('div', {
           style: { fontSize: 11, color: '#9ca3af' },
         }, `RMP ${rmpData.rating.toFixed(1)}`),
-        createElement('a', {
+        parseName(instructor.name).last && createElement('a', {
           className: 'trp-cis-link',
-          href: `https://cis.tamu.edu/results?instructor=${encodeURIComponent(lastName)}`,
+          href: `https://cis.tamu.edu/results?instructor=${encodeURIComponent(parseName(instructor.name).last)}`,
           target: '_blank',
           rel: 'noopener noreferrer',
         }, 'CIS'),

--- a/src/content/components/CourseSearch.tsx
+++ b/src/content/components/CourseSearch.tsx
@@ -217,6 +217,12 @@ function InstructorCard({
         rmpData && createElement('div', {
           style: { fontSize: 11, color: '#9ca3af' },
         }, `RMP ${rmpData.rating.toFixed(1)}`),
+        createElement('a', {
+          className: 'trp-cis-link',
+          href: `https://cis.tamu.edu/results?instructor=${encodeURIComponent(lastName)}`,
+          target: '_blank',
+          rel: 'noopener noreferrer',
+        }, 'CIS'),
         createElement('button', {
           onClick: handleAddToBuilder,
           disabled: addState === 'loading' || addState === 'done',

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -245,6 +245,17 @@ function injectBadge(nameSpan: Element, gradeData: GradeData | null, rmpData: Rm
   }
 
   nameSpan.after(badge);
+
+  const lastName = nameSpan.textContent?.split(/[\s,]+/).filter(Boolean).pop() ?? '';
+  if (lastName) {
+    const cisLink = document.createElement('a');
+    cisLink.className = 'trp-cis-link';
+    cisLink.href = `https://cis.tamu.edu/results?instructor=${encodeURIComponent(lastName)}`;
+    cisLink.target = '_blank';
+    cisLink.rel = 'noopener noreferrer';
+    cisLink.textContent = 'CIS';
+    badge.after(cisLink);
+  }
 }
 
 // ─── per-element processing ───────────────────────────────────────────────────

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -7,6 +7,7 @@ import type { PageStats } from '../shared/messages';
 import type { GradeData, MeetingTime, RmpData, SavedSection, SeatData, SectionStatus } from '../shared/types';
 import { storageGet, saveSection, removeSection } from '../shared/storage';
 import { parseMeetingFromApi } from '../shared/conflictDetection';
+import { parseName } from '../shared/nameMatch';
 import { gpaColorClass } from '../shared/gradeUtils';
 import { mountPanel, rerenderPanel, unmountPanel } from './mount';
 import SectionComparison, { type InstructorData } from './components/SectionComparison';
@@ -246,7 +247,7 @@ function injectBadge(nameSpan: Element, gradeData: GradeData | null, rmpData: Rm
 
   nameSpan.after(badge);
 
-  const lastName = nameSpan.textContent?.split(/[\s,]+/).filter(Boolean).pop() ?? '';
+  const { last: lastName } = parseName(nameSpan.textContent?.trim() ?? '');
   if (lastName) {
     const cisLink = document.createElement('a');
     cisLink.className = 'trp-cis-link';

--- a/src/content/styles/content.css
+++ b/src/content/styles/content.css
@@ -227,6 +227,30 @@
   color: #500000;
 }
 
+/* ─── CIS link ──────────────────────────────────────────────────────────────── */
+
+.trp-cis-link {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 4px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  color: #9ca3af;
+  background: none;
+  border: 1px solid #374151;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.4;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.trp-cis-link:hover {
+  color: #f9fafb;
+  border-color: #6b7280;
+}
+
 /* ─── Section status badges ─────────────────────────────────────────────────── */
 
 .trp-status-badge {


### PR DESCRIPTION
## Summary
- Injects a small `CIS` link badge next to each instructor name on the schedule builder page (after the GPA/RMP badge)
- Adds the same link inside `InstructorCard` in the CourseSearch panel
- Links point to `https://cis.tamu.edu/results?instructor=<last_name>` and open in a new tab
- New `.trp-cis-link` CSS class — understated pill style consistent with existing badges

Closes #10