### PR TITLE
add manual seat refresh button to saved sections popup

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -3,7 +3,7 @@
 import { GRADES_API, RMP_URL, RMP_SCHOOL_ID, RMP_AUTH, RMP_QUERY, GRADE_TTL_MS, RMP_TTL_MS } from '../shared/constants';
 import { matchProf, pickBestRmp, parseName } from '../shared/nameMatch';
 import type { GradeData, RmpData, ApiSection } from '../shared/types';
-import type { LookupResponse, CourseSearchResponse, RankedInstructor, FetchSectionsResponse, AddCourseResponse } from '../shared/messages';
+import type { LookupResponse, CourseSearchResponse, RankedInstructor, FetchSectionsResponse, AddCourseResponse, RefreshSectionsResponse } from '../shared/messages';
 
 const SCHEDULER_BASE = 'https://tamu.collegescheduler.com';
 
@@ -273,6 +273,69 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       } catch (e) {
         console.error('ADD_COURSE_TO_BUILDER error:', e);
         sendResponse({ ok: false } satisfies AddCourseResponse);
+      }
+    })();
+    return true;
+  }
+
+  if (msg.type === 'REFRESH_SECTIONS') {
+    (async () => {
+      try {
+        const stored = await chrome.storage.local.get(['savedSections', 'currentTerm']);
+        const savedSections = (stored.savedSections ?? {}) as Record<string, import('../shared/types').SavedSection>;
+        const term = (stored.currentTerm as string | undefined) ?? 'Spring 2026 - College Station';
+
+        // Group CRNs by dept+courseNumber to deduplicate regblocks calls
+        const courseMap = new Map<string, { dept: string; number: string; crns: string[] }>();
+        for (const [crn, section] of Object.entries(savedSections)) {
+          const key = `${section.dept}_${section.courseNumber}`;
+          if (!courseMap.has(key)) courseMap.set(key, { dept: section.dept, number: section.courseNumber, crns: [] });
+          courseMap.get(key)!.crns.push(crn);
+        }
+
+        // Fetch regblocks for each unique course, collect seat data by CRN
+        const seatsByCrn = new Map<string, import('../shared/types').SeatData>();
+        await Promise.all(
+          Array.from(courseMap.values()).map(async ({ dept, number }) => {
+            try {
+              const url = `${SCHEDULER_BASE}/api/terms/${encodeURIComponent(term)}/subjects/${dept.toUpperCase()}/courses/${number}/regblocks`;
+              const res = await fetch(url, { credentials: 'include' });
+              if (!res.ok) return;
+              const data = await res.json() as {
+                sections?: { crn?: number | string; openSeats?: number; totalSeats?: number; waitlistCount?: number }[];
+              };
+              for (const s of data.sections ?? []) {
+                if (s.crn == null) continue;
+                seatsByCrn.set(String(s.crn), {
+                  openSeats: s.openSeats,
+                  totalSeats: s.totalSeats,
+                  waitlistCount: s.waitlistCount,
+                });
+              }
+            } catch { /* ignore per-course failure */ }
+          })
+        );
+
+        if (seatsByCrn.size === 0) {
+          sendResponse({ updatedCount: 0, timestamp: Date.now() } satisfies RefreshSectionsResponse);
+          return;
+        }
+
+        const timestamp = Date.now();
+        let updatedCount = 0;
+        for (const [crn, section] of Object.entries(savedSections)) {
+          const seats = seatsByCrn.get(crn);
+          if (seats) {
+            savedSections[crn] = { ...section, seatData: seats, lastRefreshed: timestamp };
+            updatedCount++;
+          }
+        }
+
+        await chrome.storage.local.set({ savedSections });
+        sendResponse({ updatedCount, timestamp } satisfies RefreshSectionsResponse);
+      } catch (err) {
+        console.error('REFRESH_SECTIONS error:', err);
+        sendResponse({ updatedCount: 0, timestamp: Date.now() } satisfies RefreshSectionsResponse);
       }
     })();
     return true;

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -279,31 +279,39 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   }
 
   if (msg.type === 'REFRESH_SECTIONS') {
+    const { term } = msg as { type: 'REFRESH_SECTIONS'; term: string };
     (async () => {
       try {
-        const stored = await chrome.storage.local.get(['savedSections', 'currentTerm']);
+        const stored = await chrome.storage.local.get('savedSections');
         const savedSections = (stored.savedSections ?? {}) as Record<string, import('../shared/types').SavedSection>;
-        const term = (stored.currentTerm as string | undefined) ?? 'Spring 2026 - College Station';
 
-        // Group CRNs by dept+courseNumber to deduplicate regblocks calls
-        const courseMap = new Map<string, { dept: string; number: string; crns: string[] }>();
-        for (const [crn, section] of Object.entries(savedSections)) {
+        // Group by dept+courseNumber to deduplicate regblocks calls
+        const courseMap = new Map<string, { dept: string; number: string }>();
+        for (const section of Object.values(savedSections)) {
           const key = `${section.dept}_${section.courseNumber}`;
-          if (!courseMap.has(key)) courseMap.set(key, { dept: section.dept, number: section.courseNumber, crns: [] });
-          courseMap.get(key)!.crns.push(crn);
+          if (!courseMap.has(key)) courseMap.set(key, { dept: section.dept, number: section.courseNumber });
         }
 
-        // Fetch regblocks for each unique course, collect seat data by CRN
+        if (courseMap.size === 0) {
+          sendResponse({ updatedCount: 0, timestamp: Date.now() } satisfies RefreshSectionsResponse);
+          return;
+        }
+
+        // Fetch regblocks for each unique course; collect seat data by CRN
         const seatsByCrn = new Map<string, import('../shared/types').SeatData>();
+        let fetchSucceeded = 0;
         await Promise.all(
           Array.from(courseMap.values()).map(async ({ dept, number }) => {
             try {
+              const ac = new AbortController();
+              setTimeout(() => ac.abort(), 8000);
               const url = `${SCHEDULER_BASE}/api/terms/${encodeURIComponent(term)}/subjects/${dept.toUpperCase()}/courses/${number}/regblocks`;
-              const res = await fetch(url, { credentials: 'include' });
+              const res = await fetch(url, { credentials: 'include', signal: ac.signal });
               if (!res.ok) return;
               const data = await res.json() as {
                 sections?: { crn?: number | string; openSeats?: number; totalSeats?: number; waitlistCount?: number }[];
               };
+              fetchSucceeded++;
               for (const s of data.sections ?? []) {
                 if (s.crn == null) continue;
                 seatsByCrn.set(String(s.crn), {
@@ -316,26 +324,30 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           })
         );
 
-        if (seatsByCrn.size === 0) {
-          sendResponse({ updatedCount: 0, timestamp: Date.now() } satisfies RefreshSectionsResponse);
+        // All fetches failed — likely session expired
+        if (fetchSucceeded === 0) {
+          sendResponse({ updatedCount: 0, timestamp: Date.now(), error: true } satisfies RefreshSectionsResponse);
           return;
         }
 
+        // Re-read storage right before write to minimize race window with concurrent saves/removes
+        const fresh = await chrome.storage.local.get('savedSections');
+        const sections = (fresh.savedSections ?? {}) as Record<string, import('../shared/types').SavedSection>;
         const timestamp = Date.now();
         let updatedCount = 0;
-        for (const [crn, section] of Object.entries(savedSections)) {
+        for (const [crn, section] of Object.entries(sections)) {
           const seats = seatsByCrn.get(crn);
           if (seats) {
-            savedSections[crn] = { ...section, seatData: seats, lastRefreshed: timestamp };
+            sections[crn] = { ...section, seatData: seats, lastRefreshed: timestamp };
             updatedCount++;
           }
         }
 
-        await chrome.storage.local.set({ savedSections });
+        await chrome.storage.local.set({ savedSections: sections });
         sendResponse({ updatedCount, timestamp } satisfies RefreshSectionsResponse);
       } catch (err) {
         console.error('REFRESH_SECTIONS error:', err);
-        sendResponse({ updatedCount: 0, timestamp: Date.now() } satisfies RefreshSectionsResponse);
+        sendResponse({ updatedCount: 0, timestamp: Date.now(), error: true } satisfies RefreshSectionsResponse);
       }
     })();
     return true;

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { sendGetPageStats, sendCourseSearch, sendFetchSections, sendAddCourseToBuilder, sendRefreshSections } from '../shared/messages';
 import type { PageStats, RankedInstructor } from '../shared/messages';
 import { storageGet, removeSection, saveSection, storageOnChanged } from '../shared/storage';
 import { findConflicts } from '../shared/conflictDetection';
-import type { SavedSection, Schedule, ApiSection } from '../shared/types';
+import type { SavedSection, Schedule, ApiSection, SectionStatus } from '../shared/types';
 
 const SCHEDULER_HOST = 'tamu.collegescheduler.com';
 const DEFAULT_TERM = 'Spring 2026 - College Station';
@@ -159,11 +159,41 @@ function autoColor(dept: string, num: string): string {
 
 const COOLDOWN_MS = 3000;
 
-function seatStatus(seatData: import('../shared/types').SeatData): 'OPEN' | 'WAITLISTED' | 'CLOSED' | null {
+function seatStatus(seatData: import('../shared/types').SeatData): SectionStatus | null {
   if (seatData.openSeats === undefined && seatData.waitlistCount === undefined) return null;
   if ((seatData.openSeats ?? 0) > 0) return 'OPEN';
   if ((seatData.waitlistCount ?? 0) > 0) return 'WAITLISTED';
   return 'CLOSED';
+}
+
+const STATUS_STYLE: Record<SectionStatus, { bg: string; color: string; border: string }> = {
+  OPEN:       { bg: '#d1fae5', color: '#065f46', border: '#6ee7b7' },
+  WAITLISTED: { bg: '#fef9c3', color: '#713f12', border: '#fde047' },
+  CLOSED:     { bg: '#fee2e2', color: '#7f1d1d', border: '#fca5a5' },
+};
+
+function SeatInfo({ seatData }: { seatData: import('../shared/types').SeatData }) {
+  const status = seatStatus(seatData);
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      {seatData.openSeats !== undefined && (
+        <span>{seatData.openSeats}/{seatData.totalSeats ?? '?'} open</span>
+      )}
+      {status && (
+        <span style={{
+          padding: '0 5px',
+          borderRadius: 8,
+          fontSize: 9,
+          fontWeight: 700,
+          background: STATUS_STYLE[status].bg,
+          color: STATUS_STYLE[status].color,
+          border: `1px solid ${STATUS_STYLE[status].border}`,
+        }}>
+          {status}
+        </span>
+      )}
+    </div>
+  );
 }
 
 function formatRelativeTime(ts: number): string {
@@ -188,21 +218,26 @@ function SavedTab({
 }) {
   const [pickerCrn, setPickerCrn] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
-  const [lastClickedAt, setLastClickedAt] = useState(0);
+  const [cooldownActive, setCooldownActive] = useState(false);
   const [refreshError, setRefreshError] = useState(false);
+  const cooldownTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => { if (cooldownTimer.current) clearTimeout(cooldownTimer.current); };
+  }, []);
 
   if (sections.length === 0) {
     return <div style={C.empty}>No saved sections yet.<br />Click ☆ on any section to save it.</div>;
   }
 
   const conflicts = findConflicts(sections);
-  const cooldownActive = Date.now() - lastClickedAt < COOLDOWN_MS;
 
   async function handleRefresh() {
     if (refreshing || cooldownActive) return;
     setRefreshing(true);
     setRefreshError(false);
-    setLastClickedAt(Date.now());
+    setCooldownActive(true);
+    cooldownTimer.current = setTimeout(() => setCooldownActive(false), COOLDOWN_MS);
     const ok = await onRefresh();
     setRefreshing(false);
     if (!ok) setRefreshError(true);
@@ -284,35 +319,11 @@ function SavedTab({
                   </span>
                 )}
               </div>
-              {s.seatData && (() => {
-                const status = seatStatus(s.seatData);
-                const statusColors: Record<string, { bg: string; color: string; border: string }> = {
-                  OPEN: { bg: '#d1fae5', color: '#065f46', border: '#6ee7b7' },
-                  WAITLISTED: { bg: '#fef9c3', color: '#713f12', border: '#fde047' },
-                  CLOSED: { bg: '#fee2e2', color: '#7f1d1d', border: '#fca5a5' },
-                };
-                const style = status ? statusColors[status] : null;
-                return (
-                  <div style={{ ...C.savedMeta, marginTop: 3, display: 'flex', alignItems: 'center', gap: 6 }}>
-                    {s.seatData.openSeats !== undefined && (
-                      <span>{s.seatData.openSeats}/{s.seatData.totalSeats ?? '?'} open</span>
-                    )}
-                    {status && style && (
-                      <span style={{
-                        padding: '0 5px',
-                        borderRadius: 8,
-                        fontSize: 9,
-                        fontWeight: 700,
-                        background: style.bg,
-                        color: style.color,
-                        border: `1px solid ${style.border}`,
-                      }}>
-                        {status}
-                      </span>
-                    )}
-                  </div>
-                );
-              })()}
+              {s.seatData && (
+                <div style={{ ...C.savedMeta, marginTop: 3 }}>
+                  <SeatInfo seatData={s.seatData} />
+                </div>
+              )}
               {isPickerOpen && (
                 <div style={{ display: 'flex', gap: 5, marginTop: 8, flexWrap: 'wrap' as const }}>
                   {SWATCH_COLORS.map((color) => (
@@ -656,8 +667,10 @@ export default function App() {
   };
 
   const handleRefresh = async (): Promise<boolean> => {
-    const result = await sendRefreshSections();
-    return result !== null;
+    const stored = await chrome.storage.local.get('currentTerm');
+    const term = (stored.currentTerm as string | undefined) ?? DEFAULT_TERM;
+    const result = await sendRefreshSections(term);
+    return result !== null && !result.error;
   };
 
   const activeSchedule = schedules.find((s) => s.id === activeScheduleId) ?? null;

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { sendGetPageStats, sendCourseSearch, sendFetchSections, sendAddCourseToBuilder } from '../shared/messages';
+import { sendGetPageStats, sendCourseSearch, sendFetchSections, sendAddCourseToBuilder, sendRefreshSections } from '../shared/messages';
 import type { PageStats, RankedInstructor } from '../shared/messages';
 import { storageGet, removeSection, saveSection, storageOnChanged } from '../shared/storage';
 import { findConflicts } from '../shared/conflictDetection';
@@ -157,25 +157,93 @@ function autoColor(dept: string, num: string): string {
   return SWATCH_COLORS[h % SWATCH_COLORS.length];
 }
 
+const COOLDOWN_MS = 3000;
+
+function seatStatus(seatData: import('../shared/types').SeatData): 'OPEN' | 'WAITLISTED' | 'CLOSED' | null {
+  if (seatData.openSeats === undefined && seatData.waitlistCount === undefined) return null;
+  if ((seatData.openSeats ?? 0) > 0) return 'OPEN';
+  if ((seatData.waitlistCount ?? 0) > 0) return 'WAITLISTED';
+  return 'CLOSED';
+}
+
+function formatRelativeTime(ts: number): string {
+  const diffMs = Date.now() - ts;
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.floor(diffMin / 60);
+  return `${diffH}h ago`;
+}
+
 function SavedTab({
   sections,
   onRemove,
   onColorChange,
+  onRefresh,
 }: {
   sections: SavedSection[];
   onRemove: (crn: string) => void;
   onColorChange: (crn: string, color: string) => void;
+  onRefresh: () => Promise<boolean>;
 }) {
   const [pickerCrn, setPickerCrn] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastClickedAt, setLastClickedAt] = useState(0);
+  const [refreshError, setRefreshError] = useState(false);
 
   if (sections.length === 0) {
     return <div style={C.empty}>No saved sections yet.<br />Click ☆ on any section to save it.</div>;
   }
 
   const conflicts = findConflicts(sections);
+  const cooldownActive = Date.now() - lastClickedAt < COOLDOWN_MS;
+
+  async function handleRefresh() {
+    if (refreshing || cooldownActive) return;
+    setRefreshing(true);
+    setRefreshError(false);
+    setLastClickedAt(Date.now());
+    const ok = await onRefresh();
+    setRefreshing(false);
+    if (!ok) setRefreshError(true);
+  }
+
+  // Find the most recent lastRefreshed across all sections
+  const lastRefreshed = sections.reduce((best, s) => Math.max(best, s.lastRefreshed ?? 0), 0);
 
   return (
     <>
+      {/* Refresh row */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+        <span style={{ fontSize: 10, color: refreshError ? '#f87171' : '#4b5563' }}>
+          {refreshError
+            ? 'Refresh failed — visit Schedule Builder'
+            : lastRefreshed > 0
+              ? `Updated ${formatRelativeTime(lastRefreshed)}`
+              : 'Seat counts not yet fetched'}
+        </span>
+        <button
+          onClick={handleRefresh}
+          disabled={refreshing || cooldownActive}
+          title="Re-fetch seat counts"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            padding: '3px 8px',
+            fontSize: 10,
+            fontWeight: 600,
+            background: 'none',
+            border: '1px solid #374151',
+            borderRadius: 5,
+            color: refreshing || cooldownActive ? '#4b5563' : '#9ca3af',
+            cursor: refreshing || cooldownActive ? 'default' : 'pointer',
+          }}
+        >
+          {refreshing ? '↻ …' : '↻ Refresh'}
+        </button>
+      </div>
+
       {conflicts.size > 0 && (
         <div style={{
           background: '#7f1d1d',
@@ -216,6 +284,35 @@ function SavedTab({
                   </span>
                 )}
               </div>
+              {s.seatData && (() => {
+                const status = seatStatus(s.seatData);
+                const statusColors: Record<string, { bg: string; color: string; border: string }> = {
+                  OPEN: { bg: '#d1fae5', color: '#065f46', border: '#6ee7b7' },
+                  WAITLISTED: { bg: '#fef9c3', color: '#713f12', border: '#fde047' },
+                  CLOSED: { bg: '#fee2e2', color: '#7f1d1d', border: '#fca5a5' },
+                };
+                const style = status ? statusColors[status] : null;
+                return (
+                  <div style={{ ...C.savedMeta, marginTop: 3, display: 'flex', alignItems: 'center', gap: 6 }}>
+                    {s.seatData.openSeats !== undefined && (
+                      <span>{s.seatData.openSeats}/{s.seatData.totalSeats ?? '?'} open</span>
+                    )}
+                    {status && style && (
+                      <span style={{
+                        padding: '0 5px',
+                        borderRadius: 8,
+                        fontSize: 9,
+                        fontWeight: 700,
+                        background: style.bg,
+                        color: style.color,
+                        border: `1px solid ${style.border}`,
+                      }}>
+                        {status}
+                      </span>
+                    )}
+                  </div>
+                );
+              })()}
               {isPickerOpen && (
                 <div style={{ display: 'flex', gap: 5, marginTop: 8, flexWrap: 'wrap' as const }}>
                   {SWATCH_COLORS.map((color) => (
@@ -558,6 +655,11 @@ export default function App() {
     await saveSection({ ...section, color });
   };
 
+  const handleRefresh = async (): Promise<boolean> => {
+    const result = await sendRefreshSections();
+    return result !== null;
+  };
+
   const activeSchedule = schedules.find((s) => s.id === activeScheduleId) ?? null;
 
   return (
@@ -586,7 +688,7 @@ export default function App() {
       ) : (
         <div style={C.body}>
           {tab === 'overview' && <OverviewTab status={status} stats={stats} />}
-          {tab === 'saved' && <SavedTab sections={savedSections} onRemove={handleRemove} onColorChange={handleColorChange} />}
+          {tab === 'saved' && <SavedTab sections={savedSections} onRemove={handleRemove} onColorChange={handleColorChange} onRefresh={handleRefresh} />}
         </div>
       )}
 

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -7,7 +7,8 @@ export type Message =
   | { type: 'GET_PAGE_STATS' }
   | { type: 'COURSE_SEARCH'; dept: string; number: string }
   | { type: 'FETCH_SECTIONS'; dept: string; number: string; term: string }
-  | { type: 'ADD_COURSE_TO_BUILDER'; dept: string; number: string; term: string; sectionCrns: string[] };
+  | { type: 'ADD_COURSE_TO_BUILDER'; dept: string; number: string; term: string; sectionCrns: string[] }
+  | { type: 'REFRESH_SECTIONS' };
 
 export interface RankedInstructor {
   name: string;
@@ -124,6 +125,28 @@ export function sendCourseSearch(dept: string, number: string): Promise<CourseSe
         clearTimeout(timer);
         if (chrome.runtime.lastError || !response) {
           resolve({ instructors: [] });
+          return;
+        }
+        resolve(response);
+      },
+    );
+  });
+}
+
+export interface RefreshSectionsResponse {
+  updatedCount: number;
+  timestamp: number;
+}
+
+export function sendRefreshSections(): Promise<RefreshSectionsResponse | null> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), 30_000);
+    chrome.runtime.sendMessage(
+      { type: 'REFRESH_SECTIONS' } satisfies Message,
+      (response: RefreshSectionsResponse) => {
+        clearTimeout(timer);
+        if (chrome.runtime.lastError || !response) {
+          resolve(null);
           return;
         }
         resolve(response);

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -8,7 +8,7 @@ export type Message =
   | { type: 'COURSE_SEARCH'; dept: string; number: string }
   | { type: 'FETCH_SECTIONS'; dept: string; number: string; term: string }
   | { type: 'ADD_COURSE_TO_BUILDER'; dept: string; number: string; term: string; sectionCrns: string[] }
-  | { type: 'REFRESH_SECTIONS' };
+  | { type: 'REFRESH_SECTIONS'; term: string };
 
 export interface RankedInstructor {
   name: string;
@@ -136,13 +136,14 @@ export function sendCourseSearch(dept: string, number: string): Promise<CourseSe
 export interface RefreshSectionsResponse {
   updatedCount: number;
   timestamp: number;
+  error?: boolean;
 }
 
-export function sendRefreshSections(): Promise<RefreshSectionsResponse | null> {
+export function sendRefreshSections(term: string): Promise<RefreshSectionsResponse | null> {
   return new Promise((resolve) => {
     const timer = setTimeout(() => resolve(null), 30_000);
     chrome.runtime.sendMessage(
-      { type: 'REFRESH_SECTIONS' } satisfies Message,
+      { type: 'REFRESH_SECTIONS', term } satisfies Message,
       (response: RefreshSectionsResponse) => {
         clearTimeout(timer);
         if (chrome.runtime.lastError || !response) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -27,6 +27,8 @@ export interface SavedSection {
   rmpData: RmpData | null;
   addedAt: number;
   color?: string;
+  seatData?: SeatData;
+  lastRefreshed?: number;
 }
 
 export interface MeetingTime {


### PR DESCRIPTION
## Summary
- Adds a refresh button to the Saved tab that re-fetches seat counts from `/regblocks` for all saved sections via the background service worker
- Shows open/total seats and an OPEN/WAITLISTED/CLOSED pill on each saved section card after refresh
- Displays relative last-updated timestamp; 3-second cooldown between refresh attempts; graceful failure message if session is expired

Closes #12