### PR TITLE
Filter sections by professor when adding course to Schedule Builder

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -164,7 +164,7 @@ async function addCourseViaTab(
   dept: string,
   number: string,
   term: string,
-  sectionCrns: string[],
+  crnsToExclude: string[],
 ): Promise<boolean> {
   const existing = await chrome.tabs.query({ url: '*://tamu.collegescheduler.com/*' });
   let tabId: number;
@@ -188,40 +188,29 @@ async function addCourseViaTab(
   try {
     const results = await chrome.scripting.executeScript({
       target: { tabId },
-      func: async (dept: string, number: string, term: string, sectionCrns: string[]) => {
+      func: async (dept: string, number: string, term: string, crnsToExclude: string[]) => {
         const BASE = 'https://tamu.collegescheduler.com';
         const termEnc = encodeURIComponent(term);
         const headers = {
           'Content-Type': 'application/json',
           'X-Requested-With': 'XMLHttpRequest',
         };
+        const filterRules = crnsToExclude.length
+          ? [{ type: 'registrationNumber', values: crnsToExclude, value: null, excluded: true }]
+          : [];
         try {
           const res = await fetch(`${BASE}/api/terms/${termEnc}/desiredcourses`, {
             method: 'POST',
             credentials: 'include',
             headers,
-            body: JSON.stringify({ number, subjectId: dept.toUpperCase(), topic: null }),
+            body: JSON.stringify({ number, subjectId: dept.toUpperCase(), topic: null, filterRules }),
           });
-          if (!res.ok) return false;
-          const course = (await res.json()) as { id?: number };
-          if (course.id && sectionCrns.length) {
-            await Promise.all(
-              sectionCrns.map((crn) =>
-                fetch(`${BASE}/api/terms/${termEnc}/desiredcourses/${course.id}/lock`, {
-                  method: 'POST',
-                  credentials: 'include',
-                  headers,
-                  body: JSON.stringify({ registrationNumber: crn }),
-                }).catch(() => {}),
-              ),
-            );
-          }
-          return true;
+          return res.ok;
         } catch {
           return false;
         }
       },
-      args: [dept, number, term, sectionCrns],
+      args: [dept, number, term, crnsToExclude],
     });
     return results[0]?.result === true;
   } finally {
@@ -300,16 +289,16 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   }
 
   if (msg.type === 'ADD_COURSE_TO_BUILDER') {
-    const { dept, number, term, sectionCrns } = msg as {
+    const { dept, number, term, crnsToExclude } = msg as {
       type: 'ADD_COURSE_TO_BUILDER';
       dept: string;
       number: string;
       term: string;
-      sectionCrns: string[];
+      crnsToExclude: string[];
     };
     (async () => {
       try {
-        const ok = await addCourseViaTab(dept, number, term, sectionCrns);
+        const ok = await addCourseViaTab(dept, number, term, crnsToExclude);
         sendResponse({ ok } satisfies AddCourseResponse);
       } catch (e) {
         console.error('ADD_COURSE_TO_BUILDER error:', e);

--- a/src/content/components/CourseSearch.tsx
+++ b/src/content/components/CourseSearch.tsx
@@ -15,14 +15,17 @@ function getTerm(): string {
   return m ? decodeURIComponent(m[1]) : 'Fall 2026 - College Station';
 }
 
-async function addCourseToBuilder(dept: string, number: string): Promise<boolean> {
+async function addCourseToBuilder(dept: string, number: string, crnsToExclude: string[]): Promise<boolean> {
   const term = encodeURIComponent(getTerm());
+  const filterRules = crnsToExclude.length
+    ? [{ type: 'registrationNumber', values: crnsToExclude, value: null, excluded: true }]
+    : [];
   try {
     const res = await fetch(`${SCHEDULER_BASE}/api/terms/${term}/desiredcourses`, {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-      body: JSON.stringify({ number, subjectId: dept.toUpperCase(), topic: null }),
+      body: JSON.stringify({ number, subjectId: dept.toUpperCase(), topic: null, filterRules }),
     });
     return res.ok;
   } catch {
@@ -185,7 +188,9 @@ function InstructorCard({
 
   async function handleAddToBuilder() {
     setAddState('loading');
-    const ok = await addCourseToBuilder(dept, number);
+    const profCrns = new Set(mySections.map((s) => s.registrationNumber));
+    const crnsToExclude = sections.filter((s) => !profCrns.has(s.registrationNumber)).map((s) => s.registrationNumber);
+    const ok = await addCourseToBuilder(dept, number, crnsToExclude);
     setAddState(ok ? 'done' : 'err');
   }
 

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -403,8 +403,9 @@ function PopupInstructorCard({
   async function handleAdd() {
     setAddState('loading');
     setErrMsg('');
-    const sectionCrns = mySections.map((s) => s.registrationNumber);
-    const ok = await sendAddCourseToBuilder(dept, number, term, sectionCrns);
+    const profCrns = new Set(mySections.map((s) => s.registrationNumber));
+    const crnsToExclude = sections.filter((s) => !profCrns.has(s.registrationNumber)).map((s) => s.registrationNumber);
+    const ok = await sendAddCourseToBuilder(dept, number, term, crnsToExclude);
     setAddState(ok ? 'done' : 'err');
     if (!ok) setErrMsg('Failed — are you signed into Schedule Builder?');
   }

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -7,7 +7,7 @@ export type Message =
   | { type: 'GET_PAGE_STATS' }
   | { type: 'COURSE_SEARCH'; dept: string; number: string }
   | { type: 'FETCH_SECTIONS'; dept: string; number: string; term: string }
-  | { type: 'ADD_COURSE_TO_BUILDER'; dept: string; number: string; term: string; sectionCrns: string[] }
+  | { type: 'ADD_COURSE_TO_BUILDER'; dept: string; number: string; term: string; crnsToExclude: string[] }
   | { type: 'REFRESH_SECTIONS'; term: string };
 
 export interface RankedInstructor {
@@ -98,12 +98,12 @@ export function sendAddCourseToBuilder(
   dept: string,
   number: string,
   term: string,
-  sectionCrns: string[],
+  crnsToExclude: string[],
 ): Promise<boolean> {
   return new Promise((resolve) => {
-    const timer = setTimeout(() => resolve(false), 12_000);
+    const timer = setTimeout(() => resolve(false), 20_000);
     chrome.runtime.sendMessage(
-      { type: 'ADD_COURSE_TO_BUILDER', dept, number, term, sectionCrns } satisfies Message,
+      { type: 'ADD_COURSE_TO_BUILDER', dept, number, term, crnsToExclude } satisfies Message,
       (response: AddCourseResponse) => {
         clearTimeout(timer);
         if (chrome.runtime.lastError || !response) {


### PR DESCRIPTION
## Summary

- Fixes #21 — adding a course via the extension was selecting all sections instead of only the professor's sections
- The Schedule Builder API's `POST /desiredcourses` accepts a `filterRules` field in the body; a rule with `type: "registrationNumber"` and `excluded: true` tells it to exclude specific section CRNs
- Compute `crnsToExclude` (all sections not belonging to the selected professor) in the popup/content script and pass it in the initial POST — no separate API call needed
- Removed the old `/lock` calls which were doing the wrong thing (lock = pin during schedule optimization, not section filtering)

## How it works

```json
{
  "number": "312",
  "subjectId": "CSCE",
  "topic": null,
  "filterRules": [
    { "type": "registrationNumber", "values": ["crn1", "crn2", ...], "excluded": true }
  ]
}
```

## Test plan

- [ ] Search for a course in the popup Search tab, click "+ Builder" on a professor card
- [ ] Open Schedule Builder — verify only that professor's sections are checked
- [ ] Verify course with a single professor (crnsToExclude is empty) adds correctly with all sections
- [ ] Verify the content-script sidebar "+ Builder" button behaves the same way