### PR TITLE
settings panel

### DIFF
--- a/src/calendar/App.tsx
+++ b/src/calendar/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { storageGet, storageOnChanged, saveSchedule, deleteSchedule, setActiveSchedule, toggleCrnInSchedule } from '../shared/storage';
-import type { SavedSection, Schedule } from '../shared/types';
+import type { SavedSection, Schedule, Settings } from '../shared/types';
 import WeeklyGrid from './components/WeeklyGrid';
 
 function genId() {
@@ -98,6 +98,7 @@ export default function App() {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [renaming, setRenaming] = useState(false);
   const [renameVal, setRenameVal] = useState('');
+  const [conflictHighlight, setConflictHighlight] = useState(true);
   const renameRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -105,16 +106,19 @@ export default function App() {
       storageGet('savedSections'),
       storageGet('schedules'),
       storageGet('activeScheduleId'),
-    ]).then(([sections, scheds, active]) => {
+      storageGet('settings'),
+    ]).then(([sections, scheds, active, s]) => {
       setAllSections(sections);
       setSchedules(scheds);
       setActiveId(active);
+      setConflictHighlight(s.conflictHighlight);
     });
 
     const unsub = storageOnChanged((changes) => {
       if (changes.savedSections !== undefined) setAllSections(changes.savedSections ?? {});
       if (changes.schedules !== undefined) setSchedules(changes.schedules ?? []);
       if (changes.activeScheduleId !== undefined) setActiveId(changes.activeScheduleId ?? null);
+      if (changes.settings !== undefined) setConflictHighlight(changes.settings?.conflictHighlight ?? true);
     });
     return unsub;
   }, []);
@@ -250,7 +254,7 @@ export default function App() {
               : 'No saved sections. Save sections from Schedule Builder to see them here.'}
           </p>
         ) : (
-          <WeeklyGrid sections={displayedSections} />
+          <WeeklyGrid sections={displayedSections} conflictHighlight={conflictHighlight} />
         )}
       </div>
     </div>

--- a/src/calendar/components/WeeklyGrid.tsx
+++ b/src/calendar/components/WeeklyGrid.tsx
@@ -56,8 +56,8 @@ function blockHeight(startMin: number, endMin: number) {
   return Math.max(((endMin - startMin) / 30) * SLOT_HEIGHT - 2, 18);
 }
 
-export default function WeeklyGrid({ sections }: { sections: SavedSection[] }) {
-  const conflicts = findConflicts(sections);
+export default function WeeklyGrid({ sections, conflictHighlight = true }: { sections: SavedSection[]; conflictHighlight?: boolean }) {
+  const conflicts = conflictHighlight ? findConflicts(sections) : new Set<string>();
   const slots = Array.from({ length: TOTAL_SLOTS }, (_, i) => START_MIN + i * 30);
 
   return (

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -4,8 +4,8 @@ import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { sendLookup } from '../shared/messages';
 import type { PageStats } from '../shared/messages';
-import type { GradeData, MeetingTime, RmpData, SavedSection, SeatData, SectionStatus } from '../shared/types';
-import { storageGet, saveSection, removeSection } from '../shared/storage';
+import type { GradeData, MeetingTime, RmpData, SavedSection, SeatData, SectionStatus, Settings } from '../shared/types';
+import { storageGet, saveSection, removeSection, storageOnChanged } from '../shared/storage';
 import { parseMeetingFromApi } from '../shared/conflictDetection';
 import { parseName } from '../shared/nameMatch';
 import { gpaColorClass } from '../shared/gradeUtils';
@@ -14,6 +14,20 @@ import SectionComparison, { type InstructorData } from './components/SectionComp
 import CourseSearch from './components/CourseSearch';
 
 const BADGE_ATTR = 'data-trp';
+
+// ─── settings cache ───────────────────────────────────────────────────────────
+
+let cachedSettings: Settings = {
+  defaultTerm: 'Fall 2026 - College Station',
+  conflictHighlight: true,
+  showRmp: true,
+  showGradeBars: true,
+};
+
+storageGet('settings').then((s) => { cachedSettings = s; });
+storageOnChanged((changes) => {
+  if (changes.settings) cachedSettings = changes.settings;
+});
 
 // ─── meeting time capture (regblocks fetch intercept) ─────────────────────────
 
@@ -195,7 +209,7 @@ function getCourseFromLi(li: Element): { dept: string; number: string } | null {
 function buildTooltip(gradeData: GradeData | null, rmpData: RmpData | null): string {
   let html = '';
 
-  if (gradeData) {
+  if (gradeData && cachedSettings.showGradeBars) {
     const bars = [
       { label: 'A', pct: gradeData.pctA, cls: 'trp-bar-a' },
       { label: 'B', pct: gradeData.pctB, cls: 'trp-bar-b' },
@@ -214,9 +228,11 @@ function buildTooltip(gradeData: GradeData | null, rmpData: RmpData | null): str
       )
       .join('');
     html += `<div class="trp-meta">GPA ${gradeData.avgGpa.toFixed(2)} · ${gradeData.semCount} semester${gradeData.semCount !== 1 ? 's' : ''}</div>`;
+  } else if (gradeData) {
+    html += `<div class="trp-meta">GPA ${gradeData.avgGpa.toFixed(2)} · ${gradeData.semCount} semester${gradeData.semCount !== 1 ? 's' : ''}</div>`;
   }
 
-  if (rmpData) {
+  if (rmpData && cachedSettings.showRmp) {
     html += `<div class="trp-meta">RMP: ${rmpData.rating.toFixed(1)}/5 (${rmpData.count} ratings)</div>`;
   }
 
@@ -243,9 +259,10 @@ function injectBadge(
     const rmp = rmpData?.rating ?? null;
     const colorClass = gpaColorClass(gradeData?.avgGpa);
 
+    const rmpSpan = rmp != null && cachedSettings.showRmp ? `&nbsp;<span class="trp-rmp">★${rmp.toFixed(1)}</span>` : '';
     badge.className = `trp-badge ${colorClass}`;
     badge.innerHTML = `
-      <span class="trp-pill">GPA&nbsp;${gpa}&nbsp; A:${pctA}%${rmp != null ? `&nbsp;<span class="trp-rmp">★${rmp.toFixed(1)}</span>` : ''}</span>
+      <span class="trp-pill">GPA&nbsp;${gpa}&nbsp; A:${pctA}%${rmpSpan}</span>
       <span class="trp-tooltip">${buildTooltip(gradeData, rmpData)}</span>
     `;
   }

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { sendGetPageStats, sendCourseSearch, sendFetchSections, sendAddCourseToBuilder, sendRefreshSections } from '../shared/messages';
 import type { PageStats, RankedInstructor } from '../shared/messages';
-import { storageGet, removeSection, saveSection, saveSectionOrder, storageOnChanged } from '../shared/storage';
+import { storageGet, removeSection, saveSection, saveSectionOrder, saveSettings, storageOnChanged } from '../shared/storage';
 import { findConflicts } from '../shared/conflictDetection';
-import type { SavedSection, Schedule, ApiSection, SectionStatus } from '../shared/types';
+import type { SavedSection, Schedule, ApiSection, SectionStatus, Settings } from '../shared/types';
 
 const SCHEDULER_HOST = 'tamu.collegescheduler.com';
 const DEFAULT_TERM = 'Fall 2026 - College Station';
@@ -15,7 +15,7 @@ const TERMS = [
   'Spring 2025 - College Station',
 ];
 
-type Tab = 'overview' | 'saved' | 'search';
+type Tab = 'overview' | 'saved' | 'search' | 'settings';
 type Status = 'loading' | 'not-on-page' | 'ready';
 
 const C = {
@@ -213,6 +213,7 @@ function SavedTab({
   onRefresh,
   onImport,
   onReorder,
+  settings,
 }: {
   sections: SavedSection[];
   schedules: Schedule[];
@@ -221,6 +222,7 @@ function SavedTab({
   onRefresh: () => Promise<boolean>;
   onImport: (file: File) => Promise<string | null>;
   onReorder: (newOrder: string[]) => void;
+  settings: Settings;
 }) {
   const [pickerCrn, setPickerCrn] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
@@ -284,7 +286,7 @@ function SavedTab({
     );
   }
 
-  const conflicts = findConflicts(sections);
+  const conflicts = settings.conflictHighlight ? findConflicts(sections) : new Set<string>();
 
   async function handleRefresh() {
     if (refreshing || cooldownActive) return;
@@ -599,19 +601,20 @@ function PopupInstructorCard({
   );
 }
 
-function SearchTab({ focusCount }: { focusCount: number }) {
+function SearchTab({ focusCount, defaultTerm }: { focusCount: number; defaultTerm: string }) {
   const [query, setQuery] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [instructors, setInstructors] = useState<RankedInstructor[]>([]);
   const [sections, setSections] = useState<ApiSection[]>([]);
   const [searchedCourse, setSearchedCourse] = useState('');
-  const [term, setTerm] = useState(DEFAULT_TERM);
+  const [term, setTerm] = useState(defaultTerm);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    // Last manual choice takes precedence; fall back to settings.defaultTerm
     chrome.storage.local.get('currentTerm', (r) => {
-      if (r.currentTerm) setTerm(r.currentTerm as string);
+      setTerm((r.currentTerm as string | undefined) ?? defaultTerm);
     });
   }, []);
 
@@ -765,6 +768,89 @@ function minutesToTime(mins: number): string {
   return `${h12}:${String(m).padStart(2, '0')}${suffix}`;
 }
 
+const SETTINGS_DEFAULT: Settings = {
+  defaultTerm: 'Fall 2026 - College Station',
+  conflictHighlight: true,
+  showRmp: true,
+  showGradeBars: true,
+};
+
+function SettingsTab({
+  settings,
+  onChange,
+}: {
+  settings: Settings;
+  onChange: (patch: Partial<Settings>) => void;
+}) {
+  const row = { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14 };
+  const label = { fontSize: 11, color: '#d1d5db' };
+  const sub = { fontSize: 10, color: '#6b7280', marginTop: 2 };
+
+  function Toggle({ checked, onToggle }: { checked: boolean; onToggle: () => void }) {
+    return (
+      <button
+        onClick={onToggle}
+        style={{
+          width: 36, height: 20, borderRadius: 10, border: 'none', cursor: 'pointer', flexShrink: 0,
+          background: checked ? '#500000' : '#374151',
+          position: 'relative', transition: 'background 0.2s',
+        }}
+      >
+        <span style={{
+          position: 'absolute', top: 2, left: checked ? 18 : 2,
+          width: 16, height: 16, borderRadius: '50%', background: '#f9fafb',
+          transition: 'left 0.2s',
+        }} />
+      </button>
+    );
+  }
+
+  return (
+    <div style={{ padding: '4px 0' }}>
+      <div style={row}>
+        <div>
+          <div style={label}>Default term</div>
+          <div style={sub}>Pre-selected in course search</div>
+        </div>
+        <select
+          value={settings.defaultTerm}
+          onChange={(e) => onChange({ defaultTerm: e.target.value })}
+          style={{
+            background: '#1f2937', border: '1px solid #374151', borderRadius: 5,
+            padding: '4px 6px', fontSize: 10, color: '#9ca3af', outline: 'none', cursor: 'pointer', maxWidth: 130,
+          }}
+        >
+          {TERMS.map((t) => <option key={t} value={t}>{t.replace(' - College Station', '')}</option>)}
+        </select>
+      </div>
+
+      <div style={row}>
+        <div>
+          <div style={label}>Conflict highlight</div>
+          <div style={sub}>Warn when saved sections overlap</div>
+        </div>
+        <Toggle checked={settings.conflictHighlight} onToggle={() => onChange({ conflictHighlight: !settings.conflictHighlight })} />
+      </div>
+
+      <div style={row}>
+        <div>
+          <div style={label}>Show RMP ratings</div>
+          <div style={sub}>★ on schedule builder badges</div>
+        </div>
+        <Toggle checked={settings.showRmp} onToggle={() => onChange({ showRmp: !settings.showRmp })} />
+      </div>
+
+      <div style={row}>
+        <div>
+          <div style={label}>Show grade bars</div>
+          <div style={sub}>A/B/C bars in badge tooltip</div>
+        </div>
+        <Toggle checked={settings.showGradeBars} onToggle={() => onChange({ showGradeBars: !settings.showGradeBars })} />
+      </div>
+    </div>
+  );
+}
+
 export default function App() {
   const [tab, setTab] = useState<Tab>('overview');
   const [status, setStatus] = useState<Status>('loading');
@@ -774,6 +860,7 @@ export default function App() {
   const [activeScheduleId, setActiveScheduleId] = useState<string | null>(null);
   const [sectionOrder, setSectionOrder] = useState<string[]>([]);
   const [focusSearchCount, setFocusSearchCount] = useState(0);
+  const [settings, setSettings] = useState<Settings>(SETTINGS_DEFAULT);
 
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
@@ -797,6 +884,7 @@ export default function App() {
     });
     storageGet('schedules').then(setSchedules);
     storageGet('activeScheduleId').then(setActiveScheduleId);
+    storageGet('settings').then(setSettings);
 
     // Listen for changes from content script
     const unsub = storageOnChanged((changes) => {
@@ -806,6 +894,7 @@ export default function App() {
       if (changes.sectionOrder !== undefined) setSectionOrder(changes.sectionOrder ?? []);
       if (changes.schedules !== undefined) setSchedules(changes.schedules ?? []);
       if (changes.activeScheduleId !== undefined) setActiveScheduleId(changes.activeScheduleId ?? null);
+      if (changes.settings !== undefined) setSettings(changes.settings ?? SETTINGS_DEFAULT);
     });
 
     // Load page stats
@@ -894,6 +983,12 @@ export default function App() {
     await saveSectionOrder(newOrder);
   };
 
+  const handleSettingsChange = async (patch: Partial<Settings>) => {
+    const next = { ...settings, ...patch };
+    setSettings(next);
+    await saveSettings(next);
+  };
+
   return (
     <div style={C.wrap}>
       <div style={C.header}>
@@ -912,15 +1007,17 @@ export default function App() {
             Saved {savedSections.length > 0 ? `(${savedSections.length})` : ''}
           </button>
           <button style={C.tab(tab === 'search')} onClick={() => setTab('search')}>Search</button>
+          <button style={C.tab(tab === 'settings')} onClick={() => setTab('settings')}>⚙</button>
         </div>
       </div>
 
       {tab === 'search' ? (
-        <SearchTab focusCount={focusSearchCount} />
+        <SearchTab focusCount={focusSearchCount} defaultTerm={settings.defaultTerm} />
       ) : (
         <div style={C.body}>
           {tab === 'overview' && <OverviewTab status={status} stats={stats} />}
-          {tab === 'saved' && <SavedTab sections={orderedSections} schedules={schedules} onRemove={handleRemove} onColorChange={handleColorChange} onRefresh={handleRefresh} onImport={handleImport} onReorder={handleReorder} />}
+          {tab === 'saved' && <SavedTab sections={orderedSections} schedules={schedules} onRemove={handleRemove} onColorChange={handleColorChange} onRefresh={handleRefresh} onImport={handleImport} onReorder={handleReorder} settings={settings} />}
+          {tab === 'settings' && <SettingsTab settings={settings} onChange={handleSettingsChange} />}
         </div>
       )}
 

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -5,6 +5,12 @@ const DEFAULTS: StorageSchema = {
   schedules: [],
   activeScheduleId: null,
   sectionOrder: [],
+  settings: {
+    defaultTerm: 'Fall 2026 - College Station',
+    conflictHighlight: true,
+    showRmp: true,
+    showGradeBars: true,
+  },
 };
 
 export async function storageGet<K extends keyof StorageSchema>(key: K): Promise<StorageSchema[K]> {
@@ -82,6 +88,10 @@ export async function setActiveSchedule(id: string | null): Promise<void> {
 
 export async function saveSectionOrder(order: string[]): Promise<void> {
   await storageSet('sectionOrder', order);
+}
+
+export async function saveSettings(settings: import('./types').Settings): Promise<void> {
+  await storageSet('settings', settings);
 }
 
 // Atomic toggle of a CRN within a schedule — avoids stale-closure race

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -45,11 +45,19 @@ export interface Schedule {
   createdAt: number;
 }
 
+export interface Settings {
+  defaultTerm: string;
+  conflictHighlight: boolean;
+  showRmp: boolean;
+  showGradeBars: boolean;
+}
+
 export interface StorageSchema {
   savedSections: Record<string, SavedSection>;
   schedules: Schedule[];
   activeScheduleId: string | null;
   sectionOrder: string[];
+  settings: Settings;
 }
 
 export interface ApiMeeting {


### PR DESCRIPTION
## Summary
- New ⚙ tab in the popup with four settings, all persisted under a `settings` key in storage
- **Default term** — dropdown seeding the course search when no manual choice is stored; last manual pick still takes precedence
- **Conflict highlight** — toggling it immediately suppresses the ⚠ warning in the Saved tab and removes conflict colors in the calendar WeeklyGrid (takes effect on the schedule builder page after the next load, since the content script caches settings at init)
- **Show RMP ratings** — hides the ★ in content-script instructor badges when off
- **Show grade bars** — hides A/B/C/D/F bar chart in the badge tooltip when off; still shows the GPA + semester count line
- Settings fall back to defaults for existing users with no stored key — no migration needed

## Notes
- `autoLoad` (from the issue's "Suggested settings") was not implemented — the content script already looks up all instructors it encounters; there's no discrete manual-load event to gate
- "Conflict highlight takes effect immediately on the schedule builder page" was scoped to popup + calendar only. The schedule builder page itself has no conflict UI, so the toggle is fully effective where conflicts are actually shown

## Test plan
- [ ] Open ⚙ tab — confirm four rows render with correct defaults
- [ ] Toggle conflict highlight off — Saved tab ⚠ banner and card red border disappear immediately; calendar conflict colors disappear
- [ ] Change default term — open Search tab, confirm term dropdown matches the new default
- [ ] Toggle Show RMP off — reload Schedule Builder, confirm ★ is absent from badges
- [ ] Toggle Show grade bars off — reload Schedule Builder, hover a badge tooltip, confirm bars are gone but GPA line remains
- [ ] Settings persist after closing and reopening popup

Closes #7