### PR TITLE
What's new changelog popup on update

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "TAMU Registration+",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "GPA, grade distribution, and RMP ratings inside Schedule Builder",
   "permissions": ["storage"],
   "host_permissions": [

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -3,7 +3,7 @@ import { defineManifest } from '@crxjs/vite-plugin';
 export default defineManifest({
   manifest_version: 3,
   name: 'TAMU Registration+',
-  version: '1.0.0',
+  version: '1.1.0',
   description: 'GPA, grade distribution, and RMP ratings inside Schedule Builder',
   permissions: ['storage', 'tabs', 'scripting'],
   host_permissions: [

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -356,6 +356,14 @@ async function fetchSectionsFromHowdy(
   }
 }
 
+// ─── install / update handler ─────────────────────────────────────────────────
+
+chrome.runtime.onInstalled.addListener(({ reason }) => {
+  if (reason === 'update') {
+    chrome.storage.local.set({ showChangelog: true });
+  }
+});
+
 // ─── message handler ──────────────────────────────────────────────────────────
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
@@ -415,6 +423,33 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     (async () => {
       try {
         const sections = await fetchSectionsFromHowdy(dept, number, term);
+
+        // Opportunistically attach seat data from Schedule Builder regblocks.
+        // This works only when the user is logged in; silently skips on 401/403.
+        try {
+          const ac = new AbortController();
+          setTimeout(() => ac.abort(), 6000);
+          const url = `${SCHEDULER_BASE}/api/terms/${encodeURIComponent(term)}/subjects/${dept.toUpperCase()}/courses/${number}/regblocks`;
+          const res = await fetch(url, { credentials: 'include', signal: ac.signal });
+          if (res.ok) {
+            const data = await res.json() as {
+              sections?: { crn?: number | string; openSeats?: number; totalSeats?: number; waitlistCount?: number }[];
+            };
+            const seatMap = new Map<string, { openSeats?: number; totalSeats?: number; waitlistCount?: number }>();
+            for (const s of data.sections ?? []) {
+              if (s.crn != null) seatMap.set(String(s.crn), { openSeats: s.openSeats, totalSeats: s.totalSeats, waitlistCount: s.waitlistCount });
+            }
+            for (const s of sections) {
+              const seat = seatMap.get(s.registrationNumber);
+              if (seat) {
+                s.openSeats = seat.openSeats;
+                s.totalSeats = seat.totalSeats;
+                s.waitlistCount = seat.waitlistCount;
+              }
+            }
+          }
+        } catch { /* not logged in or network error — seat data unavailable */ }
+
         sendResponse({ sections } satisfies FetchSectionsResponse);
       } catch {
         sendResponse({ sections: [] } satisfies FetchSectionsResponse);

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -8,6 +8,29 @@ import type { SavedSection, Schedule, ApiSection, SectionStatus, Settings } from
 const SCHEDULER_HOST = 'tamu.collegescheduler.com';
 const DEFAULT_TERM = 'Fall 2026 - College Station';
 
+const CHANGELOG: { version: string; entries: string[] }[] = [
+  {
+    version: '1.1.0',
+    entries: [
+      'What\'s new popup (this one)',
+      'Settings tab: default term, conflict highlight, RMP and grade bar toggles',
+      'Seat availability badges (Open / Waitlist / Full) on saved sections',
+      'Drag-to-reorder saved sections',
+      'Export and import saved sections as JSON',
+      '"Add to Builder" button in the Search tab',
+    ],
+  },
+  {
+    version: '1.0.0',
+    entries: [
+      'Grade distribution badges on Schedule Builder course listings',
+      'RMP rating overlay on instructor names',
+      'Weekly calendar view with color-coded sections',
+      'Save sections and detect time conflicts',
+    ],
+  },
+];
+
 const TERMS = [
   'Fall 2026 - College Station',
   'Spring 2026 - College Station',
@@ -532,6 +555,11 @@ function PopupInstructorCard({
     })
   );
 
+  const sectionsWithSeats = mySections.filter((s) => s.openSeats != null);
+  const totalOpen = mySections.reduce((sum, s) => sum + (s.openSeats ?? 0), 0);
+  const anyOpen = sectionsWithSeats.some((s) => (s.openSeats ?? 0) > 0);
+  const anyWaitlist = !anyOpen && sectionsWithSeats.some((s) => (s.waitlistCount ?? 0) > 0);
+
   async function handleAdd() {
     setAddState('loading');
     setErrMsg('');
@@ -550,8 +578,19 @@ function PopupInstructorCard({
   return (
     <div style={{ background: '#1f2937', border: '1px solid #374151', borderRadius: 6, padding: '8px 10px', marginBottom: 8 }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 5, gap: 4 }}>
-        <div style={{ fontSize: 11, fontWeight: 700, color: '#f9fafb', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          {instructor.name}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 5, flex: 1, minWidth: 0, overflow: 'hidden' }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: '#f9fafb', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
+            {instructor.name}
+          </div>
+          {sectionsWithSeats.length > 0 && (
+            <span style={{
+              fontSize: 8, fontWeight: 700, padding: '1px 5px', borderRadius: 3, flexShrink: 0,
+              background: anyOpen ? '#065f46' : anyWaitlist ? '#78350f' : '#374151',
+              color: anyOpen ? '#34d399' : anyWaitlist ? '#fbbf24' : '#6b7280',
+            }}>
+              {anyOpen ? `${totalOpen} open` : anyWaitlist ? 'Waitlist' : 'Full'}
+            </span>
+          )}
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 5, flexShrink: 0 }}>
           <span style={{ fontSize: 13, fontWeight: 800, color: gpaColor(gradeData.avgGpa) }}>
@@ -592,9 +631,28 @@ function PopupInstructorCard({
         </div>
       ))}
       {mySections.length > 0 && (
-        <div style={{ marginTop: 5, fontSize: 9, color: '#6b7280' }}>
-          {mySections.slice(0, 3).map((s) => `CRN ${s.registrationNumber}`).join(' · ')}
-          {mySections.length > 3 && ` +${mySections.length - 3} more`}
+        <div style={{ marginTop: 5 }}>
+          {mySections.slice(0, 3).map((s) => {
+            const hasSeats = s.openSeats != null && s.totalSeats != null;
+            const open = s.openSeats ?? 0;
+            const waitlist = s.waitlistCount ?? 0;
+            const status = !hasSeats ? null : open > 0 ? 'OPEN' : waitlist > 0 ? 'WL' : 'FULL';
+            const pillBg = status === 'OPEN' ? '#065f46' : status === 'WL' ? '#78350f' : '#374151';
+            const pillColor = status === 'OPEN' ? '#34d399' : status === 'WL' ? '#fbbf24' : '#6b7280';
+            return (
+              <div key={s.registrationNumber} style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 9, color: '#6b7280', marginBottom: 2 }}>
+                <span style={{ fontFamily: 'monospace' }}>CRN {s.registrationNumber}</span>
+                {status && (
+                  <span style={{ fontSize: 8, fontWeight: 700, padding: '0 4px', borderRadius: 2, background: pillBg, color: pillColor }}>
+                    {status === 'OPEN' ? `${open}/${s.totalSeats}` : status === 'WL' ? `WL ${waitlist}` : 'Full'}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+          {mySections.length > 3 && (
+            <div style={{ fontSize: 9, color: '#4b5563' }}>+{mySections.length - 3} more</div>
+          )}
         </div>
       )}
       {errMsg === 'session-expired' && (
@@ -861,6 +919,75 @@ function SettingsTab({
           <div style={sub}>A/B/C bars in badge tooltip</div>
         </div>
         <Toggle checked={settings.showGradeBars} onToggle={() => onChange({ showGradeBars: !settings.showGradeBars })} />
+      </div>
+    </div>
+  );
+}
+
+function ChangelogModal({ onDismiss }: { onDismiss: () => void }) {
+  return (
+    <div style={{
+      position: 'fixed', inset: 0, zIndex: 1000,
+      background: 'rgba(0,0,0,0.7)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+    }}>
+      <div style={{
+        background: '#1f2937',
+        border: '1px solid #374151',
+        borderRadius: 10,
+        width: 280,
+        maxHeight: 420,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}>
+        <div style={{ padding: '14px 16px 10px', borderBottom: '1px solid #374151' }}>
+          <div style={{ fontSize: 13, fontWeight: 700, color: '#f9fafb', marginBottom: 2 }}>
+            What's new
+          </div>
+          <div style={{ fontSize: 10, color: '#6b7280' }}>TAMU Registration+</div>
+        </div>
+        <div style={{ overflowY: 'auto', flex: 1, padding: '12px 16px' }}>
+          {CHANGELOG.map(({ version, entries }) => (
+            <div key={version} style={{ marginBottom: 14 }}>
+              <div style={{
+                fontSize: 10,
+                fontWeight: 700,
+                color: '#500000',
+                letterSpacing: '0.05em',
+                textTransform: 'uppercase',
+                marginBottom: 6,
+              }}>
+                v{version}
+              </div>
+              <ul style={{ margin: 0, padding: '0 0 0 14px', listStyle: 'disc' }}>
+                {entries.map((e) => (
+                  <li key={e} style={{ fontSize: 11, color: '#d1d5db', marginBottom: 4, lineHeight: 1.5 }}>
+                    {e}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div style={{ padding: '10px 16px', borderTop: '1px solid #374151' }}>
+          <button
+            onClick={onDismiss}
+            style={{
+              width: '100%',
+              padding: '7px 0',
+              fontSize: 11,
+              fontWeight: 600,
+              color: '#f9fafb',
+              background: '#500000',
+              border: 'none',
+              borderRadius: 6,
+              cursor: 'pointer',
+            }}
+          >
+            Got it
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1003,6 +1003,7 @@ export default function App() {
   const [sectionOrder, setSectionOrder] = useState<string[]>([]);
   const [focusSearchCount, setFocusSearchCount] = useState(0);
   const [settings, setSettings] = useState<Settings>(SETTINGS_DEFAULT);
+  const [showChangelog, setShowChangelog] = useState(false);
 
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
@@ -1027,6 +1028,9 @@ export default function App() {
     storageGet('schedules').then(setSchedules);
     storageGet('activeScheduleId').then(setActiveScheduleId);
     storageGet('settings').then(setSettings);
+    chrome.storage.local.get('showChangelog', (r) => {
+      if (r.showChangelog) setShowChangelog(true);
+    });
 
     // Listen for changes from content script
     const unsub = storageOnChanged((changes) => {
@@ -1131,6 +1135,11 @@ export default function App() {
     await saveSettings(next);
   };
 
+  const handleDismissChangelog = () => {
+    setShowChangelog(false);
+    chrome.storage.local.remove('showChangelog');
+  };
+
   return (
     <div style={C.wrap}>
       <div style={C.header}>
@@ -1182,6 +1191,7 @@ export default function App() {
           Open Calendar
         </button>
       </div>
+      {showChangelog && <ChangelogModal onDismiss={handleDismissChangelog} />}
     </div>
   );
 }


### PR DESCRIPTION
Closes #14

## Summary
- Bumps extension to v1.1.0 so `onInstalled` fires with `reason === 'update'` for existing users
- Background service worker sets `showChangelog: true` in storage on update
- Popup reads the flag on mount and renders a `ChangelogModal` overlay exactly once
- Dismissing clears the flag from storage so it never reappears

## Test plan
- [ ] Load unpacked extension at v1.0.0, then reload with v1.1.0 build — modal appears on next popup open
- [ ] Click "Got it" — modal dismisses and does not reappear on subsequent opens
- [ ] Fresh install (not update) — no modal shown
- [ ] Run `chrome.storage.local.set({ showChangelog: true })` from popup devtools to manually trigger